### PR TITLE
feat(tx): simulate with temp pubkey

### DIFF
--- a/examples/chain/amino/20_MsgDeployEvmContract/example.ts
+++ b/examples/chain/amino/20_MsgDeployEvmContract/example.ts
@@ -92,7 +92,8 @@ const main = async () => {
   }
 
   // Simulate to estimate gas
-  let simulateRes = await simulate(txClient, txBody, [senderPubkeyAny], [senderAccSeq])
+  let simulateRes = await simulate(txClient, txBody, [senderAccSeq])
+  console.log('simulate:', simulateRes.gas_info)
   let gasLimit = Math.ceil(Number(simulateRes.gas_info.gas_used) * 1.5)
   // assign gas and other info to get real tx and broadcast
   const authInfo: txtypes.AuthInfo = {

--- a/packages/utils/tx.ts
+++ b/packages/utils/tx.ts
@@ -16,12 +16,10 @@ import keccak256 from 'keccak256'
 import { ChainGrpcTxService } from '../client/chain/grpc/ChainGrpcTxService'
 import * as ethsecp256k1 from '../../chain/cosmos/crypto/ethsecp256k1/keys'
 
-export const defaultSecp256k1Pubkey = ethsecp256k1.PubKey.create({ 
-  key: Buffer.concat([
-    Buffer.from([2]),
-    Buffer.alloc(32, 0),
-  ]) 
-})
+export const defaultSecp256k1Pubkey = () =>
+  ethsecp256k1.PubKey.create({
+    key: Buffer.concat([Buffer.from([2]), Buffer.alloc(32, 0)])
+  })
 
 export const getPublicKeyAny = (key: string): GoogleProtobufAny.Any => {
   return {
@@ -320,11 +318,7 @@ export const createTransactionWithSigners = async ({
   let fee = DEFAULT_STD_FEE
   const body = createBody({ message, memo, timeoutHeight, messageWrapper })
 
-  let simulateRes = await simulate(
-    txClient,
-    body,
-    [signer.sequence],
-  )
+  let simulateRes = await simulate(txClient, body, [signer.sequence])
 
   const gasMultiplier = 1.8
   let gasLimit = simulateRes
@@ -429,7 +423,7 @@ export const simulate = async (
     signerInfos.push({
       public_key: anytypes.Any.create({
         type_url: '/' + ethsecp256k1.PubKey.$type,
-        value: ethsecp256k1.PubKey.encode(defaultSecp256k1Pubkey).finish()
+        value: ethsecp256k1.PubKey.encode(defaultSecp256k1Pubkey()).finish()
       }),
       mode_info: {
         single: {


### PR DESCRIPTION
This will remove pubkey need to simulate the tx
Actually there will be some inaccurate in gas but for estimation purpose, it's good enough

Tried with the evm example and it looks fine

<img width="550" alt="image" src="https://github.com/FluxNFTLabs/sdk-ts/assets/30641530/6f385253-901f-4dd6-b8ce-82f5804b60d8">
